### PR TITLE
Use logger.info() for listing the identities

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -116,7 +116,7 @@ program
   .command('ls', 'list all identities')
   .action((args, options, logger) => {
     const identities = getIdentities();
-    Object.keys(identities).forEach(key => logger.log(key));
+    Object.keys(identities).forEach(key => logger.info(key));
   });
 
 program


### PR DESCRIPTION
`logger.log()` expects the `level` as first argument and the `message` as second argument.

Currently there is no output for the `ls` command because of this (`message` is undefined)´.
This PR fixes this by using `logger.info(message)`.