### PR TITLE
Format the .gitidentities file with 4 spaces

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,7 +24,7 @@ function getIdentities() {
 }
 
 function saveIdentities(identities) {
-  fs.writeFileSync(gitProfileFileLocation, JSON.stringify(identities));
+  fs.writeFileSync(gitProfileFileLocation, JSON.stringify(identities, null, 4));
 }
 
 function getCurrentIdentity(global = false) {


### PR DESCRIPTION
The current .gitidentities file puts all the data on one line because `JSON.stringify` does not set the `spaces` parameter.

This PR fixes this by setting `spaces` to `4` for indenting and formatting the generated file.